### PR TITLE
feat(next): assets proxy

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -61,6 +61,16 @@ const nextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return {
+      fallback: [
+        {
+          source: "/uploads/:path*",
+          destination: `${strapiUrl.toString()}/uploads/:path*`,
+        },
+      ],
+    };
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #124 et #139

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Quand l'admin strapi ajoute un lien vers un asset dans le gabarit, l'url généré par strapi est `/uploads/<<filename.ext>>` Ce commit rajoute un fallback sur next pour être capable de servir ses fichiers sans devoir ajouter l'url du strapi dans le gabarit