### PR TITLE
fix: add preprod/prod persistant volumes

### DIFF
--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -7,6 +7,24 @@ web:
     MAILER_SMTP_PASSWORD: ""
     MAILER_SMTP_SSL: "False"
 
+strapi:
+  addVolumes:
+    - uploads
+  volumeMounts:
+    - mountPath: /app/public/uploads
+      name: uploads
+  envFrom:
+    - secretRef:
+        name: "{{ .Values.global.pgSecretName }}"
+    - secretRef:
+        name: "mda-strapi"
+    - secretRef:
+        name: "mda-revalidate-webhook"
+    - secretRef:
+        name: "mda-meilisearch"
+    - secretRef:
+        name: "azure-mda-volume"
+
 maildev: {}
 
 jobs:

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -39,7 +39,23 @@ strapi:
     requests:
       cpu: "400m"
       memory: "512Mi"
-      
+  addVolumes:
+    - uploads
+  volumeMounts:
+    - mountPath: /app/public/uploads
+      name: uploads
+  envFrom:
+    - secretRef:
+        name: "{{ .Values.global.pgSecretName }}"
+    - secretRef:
+        name: "mda-strapi"
+    - secretRef:
+        name: "mda-revalidate-webhook"
+    - secretRef:
+        name: "mda-meilisearch"
+    - secretRef:
+        name: "azure-mda-volume"
+
 meilisearch:
   autoscale:
     enabled: true
@@ -51,4 +67,4 @@ meilisearch:
       memory: "384Mi"
     requests:
       cpu: "250m"
-      memory: "256Mi"      
+      memory: "256Mi"

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -12,10 +12,10 @@ meilisearch:
     - secretRef:
         name: "mda-meilisearch"
   env:
-     - name: MEILI_NO_ANALYTICS
-       value: "true"
+    - name: MEILI_NO_ANALYTICS
+      value: "true"
   ingress:
-     enabled: false
+    enabled: false
 
 web:
   ~chart: app
@@ -38,11 +38,6 @@ strapi:
   imagePackage: strapi
   probesPath: /_health
   host: "strapi-{{ .Values.global.host }}"
-  addVolumes:
-    - uploads
-  volumeMounts:
-    - mountPath: /app/public/uploads
-      name: uploads
   envFrom:
     - secretRef:
         name: "{{ .Values.global.pgSecretName }}"


### PR DESCRIPTION
Les secrets `azure-mda-volume` sont déjà provisionnés dans les clusters `dev/mda-preprod` et `prod/mda`