### PR TITLE
fix(breadCrumb): Do not generate title twice

### DIFF
--- a/apps/web/src/app/(main)/fiches-pratiques/[slug]/head.tsx
+++ b/apps/web/src/app/(main)/fiches-pratiques/[slug]/head.tsx
@@ -13,11 +13,7 @@ const Head = async ({ params }: FichePratiqueProps) => {
       },
     })
   ).data?.[0];
-  return (
-    <head>
-      <Next13Seo title={`Fiche pratique${currentFiche ? ` - ${currentFiche.attributes.title}` : ""}`} />
-    </head>
-  );
+  return <Next13Seo title={`Fiche pratique${currentFiche ? ` - ${currentFiche.attributes.title}` : ""}`} />;
 };
 
 export default Head;

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -1,7 +1,6 @@
 import "../../styles/global.css";
 
 import { config } from "@common/config";
-import { DEFAULT_SEO_CONFIG } from "@common/config/next-seo";
 import { BreadcrumbDynamic } from "@components/base/client/BreadcrumbDynamic";
 import { Header } from "@components/base/client/Header";
 import { DarkTheme } from "@components/utils/client/DarkTheme";
@@ -30,14 +29,12 @@ import {
 } from "@design-system";
 import { NextLinkOrA } from "@design-system/utils/NextLinkOrA";
 import Link from "next/link";
-import { NextSeo } from "next-seo";
 import { type PropsWithChildren } from "react";
 
 const RootLayout = ({ children }: PropsWithChildren) => {
   return (
     <html lang="fr">
       <head>
-        <NextSeo {...DEFAULT_SEO_CONFIG} />
         <Matomo env={config.env} />
         <TarteAuCitronGDPR env={config.env} />
         <DarkTheme />

--- a/apps/web/src/app/(main)/mon-parcours/[slug]/head.tsx
+++ b/apps/web/src/app/(main)/mon-parcours/[slug]/head.tsx
@@ -13,11 +13,7 @@ const Head = async ({ params }: ParcoursProps) => {
       },
     })
   ).data?.[0];
-  return (
-    <head>
-      <Next13Seo title={`${currentParcours ? currentParcours.attributes.title : ""}`} />
-    </head>
-  );
+  return <Next13Seo title={`${currentParcours ? currentParcours.attributes.title : ""}`} />;
 };
 
 export default Head;

--- a/apps/web/src/app/(main)/parcours/[slug]/head.tsx
+++ b/apps/web/src/app/(main)/parcours/[slug]/head.tsx
@@ -13,11 +13,7 @@ const Head = async ({ params }: FichePratiqueProps) => {
       },
     })
   ).data?.[0];
-  return (
-    <head>
-      <Next13Seo title={`Étape de vie${currentEtape ? ` - ${currentEtape.attributes.title}` : ""}`} />
-    </head>
-  );
+  return <Next13Seo title={`Étape de vie${currentEtape ? ` - ${currentEtape.attributes.title}` : ""}`} />;
 };
 
 export default Head;

--- a/apps/web/src/components/utils/Next13Seo.tsx
+++ b/apps/web/src/components/utils/Next13Seo.tsx
@@ -1,3 +1,6 @@
+import { DEFAULT_SEO_CONFIG } from "@common/config/next-seo";
 import { NextSeo, type NextSeoProps } from "next-seo";
 
-export const Next13Seo = ({ useAppDir: _, ...props }: NextSeoProps) => <NextSeo useAppDir {...props} />;
+export const Next13Seo = ({ useAppDir: _, ...props }: NextSeoProps) => (
+  <NextSeo useAppDir {...{ DEFAULT_SEO_CONFIG, ...props }} />
+);


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #65

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Le `title` de la page est généré 2 fois car 2 composants NextSeo sont utilisés. Comme toutes les pages d'appDir ont un Head.tsx qui redéfinit un NextSeo, on peut se passer de celui du layout.