### PR TITLE
fix(nginx): Support 512mb files

### DIFF
--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -47,6 +47,9 @@ strapi:
         name: "mda-revalidate-webhook"
     - secretRef:
         name: "mda-meilisearch"
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 512m
   vars:
     DATABASE_HOST: "$(PGHOST)"
     DATABASE_PORT: "$(PGPORT)"


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #191 

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Les nginx bloquent l'envoi de fichiers volumineux. Cette PR fixe leur taille limite à 512 Mb partout
