### PR TITLE
fix(prod): Increase memory limit killing pods during upload

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -35,7 +35,7 @@ strapi:
   resources:
     limits:
       cpu: "500m"
-      memory: "640Mi"
+      memory: "2Gi"
     requests:
       cpu: "400m"
       memory: "512Mi"


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #191 

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Nous constatons en production des spikes de mémoire liés aux imports de fichier qui arrêtent les pods. Cette PR a pour but d'augmenter temporairement la mémoire disponible en attendant une investigation plus approfondie de l'origine de ces pics. Cette valeur a été testée en prod sur un upload réussi 
