### PR TITLE
Revert "Revert "fix(meilisearch): Activate data share between replica…

### DIFF
--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -26,6 +26,13 @@ strapi:
     - secretRef:
         name: "azure-mda-volume"
 
+meilisearch:
+  addVolumes:
+    - meilisearch
+  volumeMounts:
+    - mountPath: /meilifiles
+      name: meilisearch
+
 maildev: {}
 
 jobs:

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -60,10 +60,14 @@ strapi:
         name: "azure-mda-volume"
 
 meilisearch:
+  replicas: 1
   autoscale:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
+    enabled: false
+  addVolumes:
+    - meilisearch
+  volumeMounts:
+    - mountPath: /meilifiles
+      name: meilisearch
   resources:
     limits:
       cpu: "350m"

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -60,6 +60,7 @@ strapi:
         name: "azure-mda-volume"
 
 meilisearch:
+  # See https://github.com/meilisearch/meilisearch-kubernetes/issues/111
   replicas: 1
   autoscale:
     enabled: false

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -5,7 +5,7 @@ global:
 
 meilisearch:
   ~chart: app
-  image: getmeili/meilisearch
+  image: getmeili/meilisearch:v1.1.0
   containerPort: 7700
   probesPath: /health
   envFrom:
@@ -14,6 +14,8 @@ meilisearch:
   env:
     - name: MEILI_NO_ANALYTICS
       value: "true"
+    - name: MEILI_DB_PATH
+      value: /meilifiles
   ingress:
     enabled: false
 


### PR DESCRIPTION
…s (#231)""

This reverts commit 7fde0ed52729fa6f2c43273a09773e2dbf688f19.

<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #230 

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Cette PR
 - active le volume pour la db de meilisearch
 - pin la version de meilisearch
 - Définit le nombre de replicas en prod à 1 (https://github.com/meilisearch/meilisearch-kubernetes/issues/111)
