### PR TITLE
fix(next): Do not cache search requests

### DIFF
--- a/apps/web/src/app/(main)/recherche/page.tsx
+++ b/apps/web/src/app/(main)/recherche/page.tsx
@@ -4,6 +4,8 @@ import { SimpleContentPage } from "@components/base/SimpleContentPage";
 import { Link } from "@design-system";
 import { mapMeilisearchHit, type SearchHit, searchStrapi } from "@services/strapi";
 
+export const dynamic = "force-dynamic";
+
 export type SearchProps = Next13ServerPageProps<"", "keyword">;
 const Search = async ({ searchParams: { keyword } }: SearchProps) => {
   const searchResults = keyword

--- a/apps/web/src/services/strapi.ts
+++ b/apps/web/src/services/strapi.ts
@@ -102,6 +102,7 @@ export async function searchStrapi(query: string): Promise<MeilisearchHit[]> {
     headers: {
       "Content-Type": "application/json",
     },
+    cache: "no-store",
   });
 
   const payload = (await response.json()) as ResponseSearch<MeilisearchHit>;


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #248 

# Objectif(s)
<!-- Expliquer en quelques mots/phrases ce que cette PR permet d'ajouter ou de résoudre -->
Suite au fix précédent, les résultats de recherche sont cachés par next
