### PR TITLE
fix(k9s): disable prod web replicas

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -97,10 +97,9 @@ web:
     - maisondelautisme.fabrique.social.gouv.fr
     - maisondelautisme-recette.fabrique.social.gouv.fr
   certSecretName: 2023-mda-web-crt
+  replicas: 1
   autoscale:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
+    enabled: false
   resources:
     limits:
       cpu: "350m"


### PR DESCRIPTION
Looks like having multiple replicas cause some weird issue with caching

https://sentry.fabrique.social.gouv.fr/organizations/incubateur/issues/101784/events/?environment=production&project=83&project=89&referrer=issue-stream&stream_index=3